### PR TITLE
Add a 'use' statement for PHP 5.3 bug.

### DIFF
--- a/src/PureMachine/Bundle/WebServiceBundle/WebService/SymfonyBaseWebService.php
+++ b/src/PureMachine/Bundle/WebServiceBundle/WebService/SymfonyBaseWebService.php
@@ -5,6 +5,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use JMS\DiExtraBundle\Annotation\Inject;
 use JMS\DiExtraBundle\Annotation\InjectParams;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use JMS\DiExtraBundle\Annotation\Service;// new Service() // PHP Bug
 
 class SymfonyBaseWebService extends BaseWebService implements ContainerAwareInterface
 {


### PR DESCRIPTION
This is a little fix for PHP 5.3 bug on annotations.
Just added the missing 'use', and a commented "new Service()" for PHP-CS-Fixer.
